### PR TITLE
Remove nodable nodes

### DIFF
--- a/app/models/queue_it/node.rb
+++ b/app/models/queue_it/node.rb
@@ -33,6 +33,10 @@ module QueueIt
       kind == 'tail'
     end
 
+    def any?
+      kind == 'any'
+    end
+
     private
 
     def repeated_kind?(kind)

--- a/app/models/queue_it/queue.rb
+++ b/app/models/queue_it/queue.rb
@@ -88,8 +88,7 @@ module QueueIt
         lock!
         old_tail_node = tail_node.lock!
         old_tail_node.update!(kind: :any)
-        new_tail_node = nodes.create!(nodable: nodable, kind: :tail)
-        old_tail_node.update!(parent_node: new_tail_node)
+        nodes.create!(nodable: nodable, kind: :tail, parent_node: old_tail_node)
       end
     end
   end

--- a/spec/concerns/queue_it/queable_spec.rb
+++ b/spec/concerns/queue_it/queable_spec.rb
@@ -82,7 +82,8 @@ describe 'Concerns::Queable' do
       end
 
       context 'when node addition is in head (in_head is true)' do
-        it 'expects first_noable to have second_nodable as parent_node and second_nodable to have third_nodable as parent_node' do
+        it 'expects first_noable to have second_nodable as parent_node and second_nodable to\
+            have third_nodable as parent_node' do
           expect(task.queue.nodes.find_by(kind: :head).nodable).to eq(third_nodable)
           expect(task.queue.nodes.find_by(kind: :any).nodable).to eq(second_nodable)
           expect(task.queue.nodes.find_by(kind: :any).parent_node.nodable).to eq(third_nodable)
@@ -145,7 +146,6 @@ describe 'Concerns::Queable' do
         expect(task.queue.nodes.find_by(kind: :tail).nodable).to eq(third_nodable)
       end
     end
-
   end
 
   describe '#formatted_queue' do
@@ -219,6 +219,191 @@ describe 'Concerns::Queable' do
       end
 
       it { expect { task.delete_queue_nodes }.to change { task.queue.size }.from(5).to(0) }
+    end
+  end
+
+  describe '#remove_from_queue' do
+    context "when queue dosen't exist or is empty" do
+      let(:nodable) { create(:user) }
+
+      it { expect(task.remove_from_queue(nodable)).to be(nil) }
+    end
+
+    context "when queue does not have the nodable in it" do
+      let(:task) { create(:task, :with_three_nodes) }
+      let(:nodable) { create(:user) }
+
+      it { expect(task.remove_from_queue(nodable)).to be(nil) }
+    end
+
+    context 'when queue has one node' do
+      let(:nodable) { create(:user) }
+
+      before { task.push_to_queue(nodable) }
+
+      it "expects to find and delete the nodables node" do
+        expect { task.remove_from_queue(nodable) }.to change { task.queue.size }.from(1).to(0)
+      end
+    end
+
+    context 'when queue has two different nodes' do
+      let(:first_nodable) { create(:user) }
+      let(:second_nodable) { create(:user) }
+      let(:in_head) { true }
+
+      before do
+        task.push_to_queue(first_nodable)
+        task.push_to_queue(second_nodable, in_head)
+      end
+
+      it "expects to delete first_nodable" do
+        expect do
+          task.remove_from_queue(first_nodable)
+        end.to change { task.queue.size }.from(2).to(1)
+        expect(task.queue.head_node.nodable).to eq(second_nodable)
+      end
+
+      it "expects to delete second_nodable" do
+        expect do
+          task.remove_from_queue(second_nodable)
+        end.to change { task.queue.size }.from(2).to(1)
+        expect(task.queue.head_node.nodable).to eq(first_nodable)
+      end
+
+      context 'when the second_nodable is added in the tail' do
+        let(:in_head) { false }
+
+        it "expects to delete first_nodable" do
+          expect do
+            task.remove_from_queue(first_nodable)
+          end.to change { task.queue.size }.from(2).to(1)
+          expect(task.queue.head_node.nodable).to eq(second_nodable)
+        end
+
+        it "expects to delete second_nodable" do
+          expect do
+            task.remove_from_queue(second_nodable)
+          end.to change { task.queue.size }.from(2).to(1)
+          expect(task.queue.head_node.nodable).to eq(first_nodable)
+        end
+      end
+    end
+
+    context 'when queue has two equal nodables' do
+      let(:nodable) { create(:user) }
+
+      before do
+        task.push_to_queue(nodable)
+        task.push_to_queue(nodable)
+      end
+
+      it "expects to delte both nodes from the queue" do
+        expect do
+          task.remove_from_queue(nodable)
+        end.to change { task.queue.size }.from(2).to(0)
+      end
+    end
+
+    context 'when queue is generic (has more than two nodes)' do
+      let(:first_nodable) { create(:user) }
+      let(:second_nodable) { create(:user) }
+      let(:third_nodable) { create(:user) }
+      let(:in_head) { true }
+
+      before do
+        task.push_to_queue(first_nodable)
+        task.push_to_queue(second_nodable, in_head)
+        task.push_to_queue(third_nodable, in_head)
+      end
+
+      it "expects to delete first_nodable's node and to have second_nodable as tail" do
+        expect do
+          task.remove_from_queue(first_nodable)
+        end.to change { task.queue.size }.from(3).to(2)
+        expect(task.queue.tail_node.nodable).to eq(second_nodable)
+      end
+
+      it "expects to delete second_nodable's node and to have first_nodable as tail" do
+        expect do
+          task.remove_from_queue(second_nodable)
+        end.to change { task.queue.size }.from(3).to(2)
+        expect(task.queue.tail_node.nodable).to eq(first_nodable)
+      end
+
+      it "expects to delete third_nodable's node and to have second_nodable as head" do
+        expect { task.remove_from_queue(third_nodable) }.to change { task.queue.size }.from(3).to(2)
+        expect(task.queue.head_node.nodable).to eq(second_nodable)
+      end
+
+      context 'when nodes are added in the tail' do
+        let(:in_head) { false }
+
+        it "expects to delete first_nodable's node and to have second_nodable as tail" do
+          expect do
+            task.remove_from_queue(first_nodable)
+          end.to change { task.queue.size }.from(3).to(2)
+          expect(task.queue.head_node.nodable).to eq(second_nodable)
+        end
+
+        it "expects to delete second_nodable's node and to have first_nodable as tail" do
+          expect do
+            task.remove_from_queue(second_nodable)
+          end.to change { task.queue.size }.from(3).to(2)
+          expect(task.queue.tail_node.nodable).to eq(third_nodable)
+        end
+
+        it "expects to delete third_nodable's node and to have second_nodable as head" do
+          expect do
+            task.remove_from_queue(third_nodable)
+          end.to change { task.queue.size }.from(3).to(2)
+          expect(task.queue.tail_node.nodable).to eq(second_nodable)
+        end
+      end
+    end
+
+    context 'when queue has three nodes but two nodables are the same' do
+      let(:first_nodable) { create(:user) }
+      let(:second_nodable) { create(:user) }
+      let(:in_head) { true }
+
+      before do
+        task.push_to_queue(first_nodable)
+        task.push_to_queue(first_nodable, in_head)
+        task.push_to_queue(second_nodable, in_head)
+      end
+
+      it "expects to delete first and second node when first_nodable is deleted" do
+        expect do
+          task.remove_from_queue(first_nodable)
+        end.to change { task.queue.size }.from(3).to(1)
+        expect(task.queue.head_node.nodable).to eq(second_nodable)
+      end
+
+      context 'when nodes are added in the tail' do
+        let(:in_head) { false }
+
+        it "expects to delete first and second node when first_nodable is deleted" do
+          expect do
+            task.remove_from_queue(first_nodable)
+          end.to change { task.queue.size }.from(3).to(1)
+          expect(task.queue.head_node.nodable).to eq(second_nodable)
+        end
+      end
+    end
+
+    context 'when queue has three nodes with the same nodable' do
+      let(:nodable) { create(:user) }
+      let(:in_head) { true }
+
+      before do
+        task.push_to_queue(nodable)
+        task.push_to_queue(nodable)
+        task.push_to_queue(nodable)
+      end
+
+      it "expects to delete first and second node when first_nodable is deleted" do
+        expect { task.remove_from_queue(nodable) }.to change { task.queue.size }.from(3).to(0)
+      end
     end
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :task do
     name { "My Task" }
+
+    trait :with_three_nodes do
+      after(:create) do |task|
+        create(:queue, :with_three_nodes, queable: task)
+      end
+    end
   end
 end

--- a/spec/models/queue_it/queue_spec.rb
+++ b/spec/models/queue_it/queue_spec.rb
@@ -94,8 +94,10 @@ module QueueIt
       let(:nodable) { create(:user) }
 
       it 'expects nodable to be in head node' do
+        old_head_node = queue.head_node
         queue.push_in_head(nodable)
         expect(queue.head_node.nodable).to eq(nodable)
+        expect(old_head_node.reload.parent_node).to eq(queue.head_node)
       end
     end
 
@@ -104,8 +106,10 @@ module QueueIt
       let(:nodable) { create(:user) }
 
       it 'expects nodable to be in tail node' do
+        old_tail_node = queue.tail_node
         queue.push_in_tail(nodable)
         expect(queue.tail_node.nodable).to eq(nodable)
+        expect(queue.tail_node.parent_node).to eq(old_tail_node)
       end
     end
   end


### PR DESCRIPTION
## Objective
Add a method to delete all the nodes associated with a nodable.

## Description
- I added a method `any?` to the `Node` model to check if the node is of kind `'any'`.
- Create method `remove_from_queue(nodable)` in `Queable` concern.
- Added multiple tests for the method.
- During the testing i found a mistake in the method `push_in_tail` of the `Queue` model. So i fix it and add a corresponding test.