### PR TITLE
Get next node custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ task.push_to_queue(User.create!(name: 'Raimundo'))
 ```
 Now with the `get_next_in_queue` method we'll the obtain user with name `'Raimundo'` and the order of the queue will be updated.
 ```ruby
-nodable = task.get_next_in_queue
+nodable = task.get_next_node_in_queue
 nodable.name == 'Raimundo' # true
 # the new order of the queue will be: [Leandro's node, Gabriel's node, Raimundo's node]
 ```
@@ -88,6 +88,32 @@ node = task.get_next_in_queue
 node.nodable.name == 'Raimundo' # true
 # the new order of the queue will be: [Leandro's node, Gabriel's node, Raimundo's node]
 ```
+
+#### Get nodable/node by custom attribute of the queue
+With the methods presented above you could only get the first nodable/node and for some cases this isn't enough. To obtain the first nodable/node that has some attribute value we've implemented the methods `get_next_in_queue_by` and `get_next_node_in_queue_by`. Both methods receive first a `nodable_attribute` and second the nodable `attribute_value` so the methods return the first nodable/node that has the attribute with the searching value.
+Let's use the same queue that we used before:
+
+``` ruby
+task = Task.create!(name: 'Example')
+task.push_to_queue(User.create!(name: 'Gabriel'))
+task.push_to_queue(User.create!(name: 'Leandro'))
+task.push_to_queue(User.create!(name: 'Raimundo'))
+# Note that the order of the queue is now: [Raimundo's node, Leandro's node, Gabriel's node]
+```
+We could now search for the second user using the attribute name 'name' and the attribute value 'Leandro' like this.
+``` ruby
+nodable = task.get_next_in_queue_by('name', 'Leandro')
+nodable.name == 'Leandro'  # true
+# the new order of the queue will now be: [Raimundo's node, Gabriel's node, Leandro's node]
+```
+Now if we would of used `get_next_node_in_queue_by` method intead of `get_next_in_queue_by` we would obtain the node containing the user with name `'Leandro'` as a nodable and the queue would of been updated aswell.
+``` ruby
+node = task.get_next_node_in_queue_by('name', 'Leandro')
+node.nodable.name == 'Leandro'  # true
+# the new order of the queue will now be: [Raimundo's node, Gabriel's node, Leandro's node]
+```
+**Note** that the methods return the first nodable/node that matches the attribute value. In case of a queue that has, for example, users with the same value you should prefer searching for another attribute like the `'id'`.
+
 
 #### Formatted Queue
 We included a method to obtain the queue formatted by an attribute/method. Note that the nodables will need to have the attribute or an implementation of the method called.

--- a/app/models/queue_it/queue.rb
+++ b/app/models/queue_it/queue.rb
@@ -27,21 +27,44 @@ module QueueIt
       size == 2
     end
 
+    def get_next_by_with_queue_length_two(nodable_attribute, attribute_value)
+      if head_node.nodable.send(nodable_attribute) == attribute_value
+        get_next_in_queue_with_length_two
+      else
+        tail_node
+      end
+    end
+
     def get_next_in_queue_with_length_two
-      next_node = ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction do
         lock!
         old_head_node = head_node.lock!
         old_tail_node = tail_node.lock!
-        nodes.where.not(kind: :any).each { |node| node.update!(kind: :any) }
+        nodes.where.not(kind: :any).find_each { |node| node.update!(kind: :any) }
         old_head_node.update!(kind: :tail, parent_node: old_tail_node)
         old_tail_node.update!(kind: :head, parent_node: nil)
         old_head_node
       end
-      next_node
+    end
+
+    def get_next_by_in_generic_queue(nodable_attribute, attribute_value)
+      if head_node.nodable.send(nodable_attribute) == attribute_value
+        return get_next_in_queue_generic
+      end
+
+      current_node = head_node.child_node
+      while !(current_node.nodable.send(nodable_attribute) == attribute_value &&
+          current_node != tail_node)
+        current_node = current_node.child_node
+        break if current_node == tail_node
+      end
+      if current_node.nodable.send(nodable_attribute) == attribute_value
+        current_node != tail_node ? move_current_node(current_node) : tail_node
+      end
     end
 
     def get_next_in_queue_generic
-      next_node = ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction do
         lock!
         old_head_node = head_node.lock!
         old_second_node = old_head_node.child_node.lock!
@@ -51,7 +74,6 @@ module QueueIt
         old_second_node.update!(kind: :head, parent_node: nil)
         old_head_node
       end
-      next_node
     end
 
     def push_node_when_queue_length_is_zero(nodable)
@@ -89,6 +111,21 @@ module QueueIt
         old_tail_node = tail_node.lock!
         old_tail_node.update!(kind: :any)
         nodes.create!(nodable: nodable, kind: :tail, parent_node: old_tail_node)
+      end
+    end
+
+    private
+
+    def move_current_node(current_node)
+      ActiveRecord::Base.transaction do
+        lock!
+        old_current_node = current_node.lock!
+        old_next_node = old_current_node.child_node.lock!
+        old_tail_node = tail_node.lock!
+        old_tail_node.update!(kind: :any)
+        old_current_node.update!(kind: :tail, parent_node: old_tail_node)
+        old_next_node.update!(parent_node: old_current_node.parent_node)
+        old_current_node
       end
     end
   end


### PR DESCRIPTION
## Objective
- Include methods to retrieve a node or a nodable by a custom nodable attribute instead of only the first one.

## Description
- I implemented methods in the `QueueIt::Queue` class to obtain the node searching by the nodable attribute for diferent queue lengths.
- I implemented the corresponding methods in the `QueueIt::Queable` concern to obtain the node or the nodable by a custom nodable attribute.
- I included tests for both classes.