### PR TITLE
Queue consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ response = task.formatted_queue('name')
 response == ['Raimundo', 'Leandro', 'Gabriel'] # true
 ```
 
+### Obtain the connected nodes of the queue
+To obtain the nodes that are connected we have implemented a method `connected_nodes`. This method is used for testing but it could be used for some other reason.
+```ruby
+# creation of the queue
+task = Task.create!(name: 'Example')
+task.push_to_queue(User.create!(name: 'Gabriel'))
+task.push_to_queue(User.create!(name: 'Leandro'))
+task.push_to_queue(User.create!(name: 'Raimundo'))
+task.connected_nodes == 3 # true
+```
+
 #### Delete all the nodes of the queue
 With the method `delete_queue_nodes` you'll be able to clean the queue.
 ```ruby

--- a/app/models/concerns/queue_it/queable.rb
+++ b/app/models/concerns/queue_it/queable.rb
@@ -26,9 +26,8 @@ module QueueIt::Queable
     def get_next_node_in_queue_by(nodable_attribute, attribute_value)
       return if local_queue.empty?
 
-      if local_queue.one_node? &&
-          local_queue.head_node.nodable.send(nodable_attribute) == attribute_value
-        return local_queue.head_node
+      if local_queue.one_node?
+        return local_queue.get_next_by_with_queue_length_one(nodable_attribute, attribute_value)
       elsif local_queue.two_nodes?
         return local_queue.get_next_by_with_queue_length_two(nodable_attribute, attribute_value)
       end
@@ -72,6 +71,16 @@ module QueueIt::Queable
           remove_node(node)
         end
       end
+    end
+
+    def connected_nodes
+      counter = 0
+      current_node = local_queue.head_node
+      while !current_node.nil?
+        counter += 1
+        current_node = current_node.child_node
+      end
+      counter
     end
 
     def local_queue


### PR DESCRIPTION
## Objective
- Fix error. When there was a queue with more than 3 nodes an the `get_next_node_in_queue_by` method to obtain, for example, the second node the connection between the nodes was broken.
- Also includes fixes for the issue #10.

## Description
- Include a method to manage the case of only one node. When the `get_next_node_in_queue_by` method was call for an object that was not in the queue (with length one) the method raised an error.
- Include validation for when the queue has length two and the `get_next_node_in_queue_by`method is called for an object that is not in the queue. Before it was retrieving the tail_node.
- Fix the `move_current_node` to properly change te conection between the nodes.
- Include a method `connected_nodes` to obtain the length of the current connected nodes.
- Add some shared examples to fix the errors mentioned.