### PR TITLE
fix(dependency): annotate config conflicting on require

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,9 +126,7 @@ GEM
     minitest (5.14.4)
     nenv (0.3.0)
     nio4r (2.5.8)
-    nokogiri (1.11.7-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.11.7-x86_64-darwin)
+    nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -251,6 +249,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   annotate (~> 3.0)
@@ -271,4 +270,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.2.24
+   2.2.33

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ rescue LoadError
   puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-APP_RAKEFILE = File.expand_path("../spec/dummy/Rakefile", __FILE__)
+APP_RAKEFILE = File.expand_path('spec/dummy/Rakefile', __dir__)
 load "rails/tasks/engine.rake"
 load "rails/tasks/statistics.rake"
 Bundler::GemHelper.install_tasks

--- a/lib/generators/queue_it/install/install_generator.rb
+++ b/lib/generators/queue_it/install/install_generator.rb
@@ -1,5 +1,5 @@
 class QueueIt::InstallGenerator < Rails::Generators::Base
-  source_root File.expand_path('../templates', __FILE__)
+  source_root File.expand_path('templates', __dir__)
 
   def create_initializer
     template "initializer.rb", "config/initializers/queue_it.rb"

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,5 +1,5 @@
-if Rails.env.development?
-  task :set_annotation_options do
+if Rails.env.development? && !Gem.loaded_specs.has_key?('rails-queue-it')
+  task set_annotation_options: :environment do
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(

--- a/queue_it.gemspec
+++ b/queue_it.gemspec
@@ -1,18 +1,21 @@
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path('lib', __dir__)
 
 # Maintain your gem"s version:
 require "queue_it/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
-  s.name          = "rails-queue-it"
-  s.version       = QueueIt::VERSION
-  s.authors       = ["Platanus", "Gabriel Lyon"]
-  s.email         = ["rubygems@platan.us", "gabriel@platan.us"]
-  s.homepage      = "https://github.com/platanus/queue-it"
-  s.summary       = "Queue's for recurrent processes that need someone (or something) responsable."
-  s.description   = "This gem allows you to queue objects through a simple to use interface."
-  s.license       = "MIT"
+  s.name                  = "rails-queue-it"
+  s.version               = QueueIt::VERSION
+  s.authors               = ["Platanus", "Gabriel Lyon"]
+  s.email                 = ["rubygems@platan.us", "gabriel@platan.us"]
+  s.homepage              = "https://github.com/platanus/queue-it"
+  s.summary               = "Queue's for recurrent processes that need someone"\
+                            "(or something) responsable."
+  s.description           = "This gem allows you to queue objects through a"\
+                            "simple to use interface."
+  s.license               = "MIT"
+  s.required_ruby_version = '>= 2.7.0'
 
   s.files = `git ls-files`.split($/).reject { |fn| fn.start_with? "spec" }
   s.bindir = "exe"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -27,4 +27,3 @@ module Dummy
     # the framework and any gems in your application.
   end
 end
-

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -81,7 +81,7 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
@@ -107,6 +107,8 @@ Rails.application.configure do
   # strategy for connection switching and pass that into the middleware through
   # these configuration options.
   # config.active_record.database_selector = { delay: 2.seconds }
-  # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  # config.active_record.database_resolver =
+  # ActiveRecord::Middleware::DatabaseSelector::Resolver
+  # config.active_record.database_resolver_context =
+  # ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 end

--- a/spec/dummy/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy/config/initializers/backtrace_silencers.rb
@@ -1,7 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
-# You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
+# You can add backtrace silencers for libraries that
+# you're using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
-# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
+# You can also remove all the silencers if
+# you're trying to debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!

--- a/spec/dummy/config/initializers/content_security_policy.rb
+++ b/spec/dummy/config/initializers/content_security_policy.rb
@@ -17,7 +17,9 @@
 # end
 
 # If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
+# Rails.application.config.content_security_policy_nonce_generator = lambda do
+# request { SecureRandom.base64(16) }
+# end
 
 # Set the nonce only to specific directives
 # Rails.application.config.content_security_policy_nonce_directives = %w(script-src)

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -4,13 +4,13 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_08_06_144346) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_08_06_144346) do
     t.integer "kind"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["nodable_type", "nodable_id"], name: "index_queue_it_nodes_on_nodable"
+    t.index %w(nodable_type nodable_id), name: "index_queue_it_nodes_on_nodable"
     t.index ["parent_node_id"], name: "index_queue_it_nodes_on_parent_node_id"
     t.index ["queue_id"], name: "index_queue_it_nodes_on_queue_id"
   end
@@ -34,7 +33,7 @@ ActiveRecord::Schema.define(version: 2021_08_06_144346) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "count_of_nodes", default: 0
-    t.index ["queable_type", "queable_id"], name: "index_queue_it_queues_on_queable"
+    t.index %w(queable_type queable_id), name: "index_queue_it_queues_on_queable"
   end
 
   create_table "tasks", force: :cascade do |t|
@@ -48,5 +47,4 @@ ActiveRecord::Schema.define(version: 2021_08_06_144346) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
-
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ SimpleCov.start do
 end
 
 ENV["RAILS_ENV"] ||= "test"
-require File.expand_path("../../spec/dummy/config/environment", __FILE__)
+require File.expand_path('../spec/dummy/config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "pry"
 require "spec_helper"


### PR DESCRIPTION
# Problema
Al usar `platanus/nest` me di cuenta que la configuración de la gema `annotate` no estaba siendo seguida.  Despues de una larga sesión de *debugging*, noté  que el problema era que estaba aplicando primero la configuración de annotate de esta gema.        , por lo que estaba causando un *conflicto* en las configuraciones.

# Solución
Ejecutar la configuración de annotate [sólo si la gema no está siendo importada por otro proyecto](https://github.com/rafafdz/queue-it/blob/6b60503d5009ca8bfb35285e4ca496bda5eb7aa0/lib/tasks/auto_annotate_models.rake#L1)

## Otros
* Se solucionaron los warnings de `rubocop`